### PR TITLE
Prevent vertical text jump in mobile layout.

### DIFF
--- a/components/layout/splash.js
+++ b/components/layout/splash.js
@@ -32,10 +32,7 @@ function Layout(props) {
                     .hero {
                       background-size: cover;
                       height: 100px;
-                    }
-                    .banner-logo {
-                      padding-top: 0;
-                      margin-bottom: -160px;
+                      margin-bottom: -44px;
                     }
                 }
             `}</style>


### PR DESCRIPTION
This change tweaks the CSS negative margins on the header to prevent text disappearing offscreen at mobile sizes.

I haven't played with Next/Vercel since it was all ZEIT. Thanks for the opportunity! 🍻 

> -44px is arbitrary-ish - it lets the podcast title continue to hang slightly below the header at the breakpoint, but once the page becomes narrow enough the title will drift up over the header image. This works with no margin change at all, but the text/title get a little too close for comfort at cell-phone size widths. 😬 

## Screencasts
_Before_
![6g0yaK9hg5](https://user-images.githubusercontent.com/4934682/92684382-51243400-f303-11ea-93e5-de39ab667c98.gif)

_After_
![SjBjbL3Jq8](https://user-images.githubusercontent.com/4934682/92684595-cabc2200-f303-11ea-93fb-2e54b7dcc750.gif)
